### PR TITLE
handle recipes with null items

### DIFF
--- a/src/main/java/com/rewindmc/retroemi/ItemStacks.java
+++ b/src/main/java/com/rewindmc/retroemi/ItemStacks.java
@@ -7,7 +7,7 @@ public class ItemStacks {
 	public static final ItemStack EMPTY = null;
 
 	public static boolean isEmpty(ItemStack stack) {
-		return stack == null || stack.stackSize == 0 || stack.getItem().delegate == null;
+		return stack == null || stack.stackSize == 0 || stack.getItem() == null ? true : stack.getItem().delegate == null;
 	}
 
 }

--- a/src/main/java/net/minecraft/util/SyntheticIdentifier.java
+++ b/src/main/java/net/minecraft/util/SyntheticIdentifier.java
@@ -61,7 +61,10 @@ public class SyntheticIdentifier {
         } else if (o instanceof EmiIngredient ei) {
             return ei.getEmiStacks().stream().map(SyntheticIdentifier::describe).collect(Collectors.joining("/", "[", "]"));
         } else if (o instanceof ItemStack is) {
-            return is.getUnlocalizedName() + "." + is.getItemDamage() + (is.hasTagCompound() ? is.getTagCompound().toString() : "");
+            if (is.getItem() == null)
+                return "null";
+            else
+                return is.getUnlocalizedName() + "." + is.getItemDamage() + (is.hasTagCompound() ? is.getTagCompound().toString() : "");
         } else if (o instanceof Block) {
             return describe(new ItemStack((Block) o));
         } else if (o instanceof String) {


### PR DESCRIPTION
this fixes a few mod's adding recipes with an item that isn't registered to prevent EMI plugins from loading, namely et futurem requiem's currently version has a moss block recipe that enabled regardless if the moss block it self is