### PR TITLE
Fix hodgepodge crash

### DIFF
--- a/src/main/java/dev/emi/emi/mixin/InventoryEffectRendererMixin.java
+++ b/src/main/java/dev/emi/emi/mixin/InventoryEffectRendererMixin.java
@@ -46,9 +46,7 @@ public abstract class InventoryEffectRendererMixin extends GuiContainer {
 		guiLeft = Math.max(guiLeft, REMIMixinHooks.EFFECT_WIDTH);
 	}
 
-	@Inject(at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/client/gui/inventory/GuiContainer;drawScreen(IIF)V", shift = At.Shift.AFTER),
-		method = "drawScreen")
+	@Inject(at = @At(value = "HEAD"), method = "drawScreen")
 	private void drawScreen(int mouseX, int mouseY, float par3, CallbackInfo ci) {
 		if (EmiConfig.effectLocation == EffectLocation.TOP) {
 			emi$drawCenteredEffects(DrawContext.INSTANCE, mouseX, mouseY);


### PR DESCRIPTION
Fixes this:
```
[RFB-Main/FATAL] [mixin]: Mixin apply for mod emi failed mixins.emi.json:InventoryEffectRendererMixin from mod emi -> net.minecraft.client.renderer.InventoryEffectRenderer: org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException InjectionPoint(Shift)[@At("INVOKE")] on net/minecraft/client/renderer/InventoryEffectRenderer::drawScreen with priority 1000 cannot inject into net/minecraft/client/renderer/InventoryEffectRenderer::func_73863_a(IIF)V merged by com.mitchej123.hodgepodge.mixins.early.minecraft.MixinInventoryEffectRenderer_PotionEffectRendering with priority 1000 [INJECT_PREPARE Applicator Phase -> mixins.emi.json:InventoryEffectRendererMixin from mod emi -> Prepare Injections -> handler$zzm000$emi$drawScreen(IIFLorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V -> Prepare ->  -> { target: func_73863_a(IIF)V }]
org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException: InjectionPoint(Shift)[@At("INVOKE")] on net/minecraft/client/renderer/InventoryEffectRenderer::drawScreen with priority 1000 cannot inject into net/minecraft/client/renderer/InventoryEffectRenderer::func_73863_a(IIF)V merged by com.mitchej123.hodgepodge.mixins.early.minecraft.MixinInventoryEffectRenderer_PotionEffectRendering with priority 1000 [INJECT_PREPARE Applicator Phase -> mixins.emi.json:InventoryEffectRendererMixin from mod emi -> Prepare Injections -> handler$zzm000$emi$drawScreen(IIFLorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V -> Prepare ->  -> { target: func_73863_a(IIF)V }]
	at System//org.spongepowered.asm.mixin.injection.code.Injector.findTargetNodes(Injector.java:312) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.injection.code.Injector.find(Injector.java:248) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.injection.struct.InjectionInfo.prepare(InjectionInfo.java:475) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinTargetContext.prepareInjections(MixinTargetContext.java:1406) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.prepareInjections(MixinApplicatorStandard.java:731) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyMixin(MixinApplicatorStandard.java:315) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.apply(MixinApplicatorStandard.java:246) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.TargetClassContext.apply(TargetClassContext.java:437) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.TargetClassContext.applyMixins(TargetClassContext.java:418) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:351) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClass(MixinTransformer.java:237) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClassBytes(MixinTransformer.java:202) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//org.spongepowered.asm.mixin.transformer.Proxy.transform(Proxy.java:72) ~[+unimixins-all-1.7.10-0.3.1.jar:0.15.6+mixin.0.8.7]
	at System//net.minecraft.launchwrapper.LaunchClassLoader.runTransformers(LaunchClassLoader.java:409) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at System//net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:293) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
	at java.base/java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027) ~[?:?]
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150) ~[?:?]
	at System//net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:334) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
	at Launch//net.minecraft.client.main.Main.main(SourceFile:72) ~[minecraft-1.7.10-client.jar:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47) ~[lwjgl3ify-3.0.26-forgePatches.jar:3.0.26]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```