### PR TITLE
Set indent style to tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-indent_style = space
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Seems like you're using tab for indents, but `.editorconfig` is set to space. Let's make this a rule by changing `.editorconfig`